### PR TITLE
Add support for arrays of integers and floats in swagger generator

### DIFF
--- a/lib/apipie/swagger_generator.rb
+++ b/lib/apipie/swagger_generator.rb
@@ -476,10 +476,14 @@ module Apipie
 
       if swagger_def[:type] == "array"
         array_of_validator_opts = param_desc.validator.param_description.options
-        items_type = array_of_validator_opts[:of].to_s || array_of_validator_opts[:array_of].to_s
-        if items_type == "Hash"
+        items_type = array_of_validator_opts[:of] || array_of_validator_opts[:array_of]
+        if items_type == Hash
           ref_name = "#{swagger_op_id_for_path(param_desc.method_description.apis.first.http_method, param_desc.method_description.apis.first.path)}_param_#{param_desc.name}"
           swagger_def[:items] = {"$ref" => gen_referenced_block_from_params_array(ref_name, param_desc.validator.param_description.validator.params_ordered, allow_nulls)}
+        elsif items_type == Integer
+          swagger_def[:items] = {type: "integer"}
+        elsif items_type == Float
+          swagger_def[:items] = {type: "number"}
         else
           swagger_def[:items] = {type: "string"}
         end


### PR DESCRIPTION
Currently parameters declared as arrays of `Integer` or `Float` will be encoded as an array of strings during Swagger generation. This PR modifies the Swagger generator behaviour to encode `Integer` arrays to item type `integer` and `Float` arrays to item type `number`.