### PR TITLE
Pass resources to Swagger generator in alphabetical order

### DIFF
--- a/lib/apipie/swagger_generator.rb
+++ b/lib/apipie/swagger_generator.rb
@@ -38,7 +38,7 @@ module Apipie
 
       @lang = lang
       @only_method = method_name
-      add_resources(resources)
+      add_resources(resources.sort.to_h)
 
       @swagger[:info]["x-computed-id"] = @computed_interface_id if Apipie.configuration.swagger_generate_x_computed_id_field?
       return @swagger

--- a/lib/apipie/swagger_generator.rb
+++ b/lib/apipie/swagger_generator.rb
@@ -38,6 +38,8 @@ module Apipie
 
       @lang = lang
       @only_method = method_name
+      # The resources hash is sorted to ensure output order is not dependent on module load order which could
+      # vary between environments.
       add_resources(resources.sort.to_h)
 
       @swagger[:info]["x-computed-id"] = @computed_interface_id if Apipie.configuration.swagger_generate_x_computed_id_field?


### PR DESCRIPTION
Currently resource definitions are passed to the Swagger generator in the order they were defined (i.e. in order the controller files were interpreted). It seems that the load order may vary between environments in some cases (e.g. may be different on macOS vs. Linux).

This PR sorts the resources Hash keys alphabetically prior to adding them to the Swagger generator. This should ensure consistency between environments.