### PR TITLE
Add `show` flag to `resource_description`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -142,6 +142,9 @@ meta
 deprecated
   Boolean value indicating if the resource is marked as deprecated. (Default false)
 
+show
+  Resource is hidden from documentation when set to false (true by default)
+
 Example:
 ~~~~~~~~
 

--- a/lib/apipie/dsl_definition.rb
+++ b/lib/apipie/dsl_definition.rb
@@ -84,6 +84,10 @@ module Apipie
         _apipie_dsl_data[:deprecated] = value
       end
 
+      def show(value)
+        _apipie_dsl_data[:show] = value
+      end
+
     end
 
     module Action

--- a/lib/apipie/resource_description.rb
+++ b/lib/apipie/resource_description.rb
@@ -15,7 +15,7 @@ module Apipie
 
     attr_reader :controller, :_short_description, :_full_description, :_methods, :_id,
       :_path, :_name, :_params_args, :_returns_args, :_tag_list_arg, :_errors_args,
-      :_formats, :_parent, :_metadata, :_headers, :_deprecated
+      :_formats, :_parent, :_metadata, :_headers, :_deprecated, :_show
 
     def initialize(controller, resource_name, dsl_data = nil, version = nil, &block)
 
@@ -29,6 +29,7 @@ module Apipie
       @_version = version || Apipie.configuration.default_version
       @_name = @_id.humanize
       @_parent = Apipie.get_resource_description(controller.superclass, version)
+      @_show = true
 
       update_from_dsl_data(dsl_data) if dsl_data
     end
@@ -47,6 +48,11 @@ module Apipie
       @_api_base_url = dsl_data[:api_base_url]
       @_headers = dsl_data[:headers]
       @_deprecated = dsl_data[:deprecated] || false
+      @_show = if dsl_data.has_key? :show
+        dsl_data[:show]
+      else
+        true
+      end
 
       if dsl_data[:app_info]
         Apipie.configuration.app_info[_version] = dsl_data[:app_info]
@@ -116,7 +122,8 @@ module Apipie
         :metadata => @_metadata,
         :methods => methods,
         :headers => _headers,
-        :deprecated => @_deprecated
+        :deprecated => @_deprecated,
+        :show => @_show
       }
     end
 

--- a/lib/apipie/swagger_generator.rb
+++ b/lib/apipie/swagger_generator.rb
@@ -106,6 +106,7 @@ module Apipie
 
     def add_resources(resources)
       resources.each do |resource_name, resource_defs|
+        next if !resource_defs._show
         add_resource_description(resource_name, resource_defs)
         add_resource_methods(resource_name, resource_defs)
       end


### PR DESCRIPTION
Add a `show` parameter to the `resource_description` DSL, similar to that of method_description. Even all methods are hidden from a controller, the controller would still be exposed as a `tag` in the swagger file. 