### PR TITLE
Fix incorrect namespaced controller names in rspec validators

### DIFF
--- a/lib/apipie/rspec/response_validation_helper.rb
+++ b/lib/apipie/rspec/response_validation_helper.rb
@@ -89,10 +89,11 @@ class ActionController::Base
     # this method is injected into ActionController::Base in order to
     # get access to the names of the current controller, current action, as well as to the response
     def schema_validation_errors_for_response
-      unprocessed_schema = Apipie::json_schema_for_method_response(controller_name, action_name, response.code, true)
+      resource_name = Apipie::app.get_resource_name(self.class)
+      unprocessed_schema = Apipie::json_schema_for_method_response(resource_name, action_name, response.code, true)
 
       if unprocessed_schema.nil?
-        err = "no schema defined for #{controller_name}##{action_name}[#{response.code}]"
+        err = "no schema defined for #{resource_name}##{action_name}[#{response.code}]"
         return [nil, [err], RuntimeError.new(err)]
       end
 
@@ -100,7 +101,7 @@ class ActionController::Base
 
       error_list = JSON::Validator.fully_validate(schema, response.body, :strict => false, :version => :draft4, :json => true)
 
-      error_object = Apipie::ResponseDoesNotMatchSwaggerSchema.new(controller_name, action_name, response.code, error_list, schema, response.body)
+      error_object = Apipie::ResponseDoesNotMatchSwaggerSchema.new(resource_name, action_name, response.code, error_list, schema, response.body)
 
       [schema, error_list, error_object]
     rescue Apipie::NoDocumentedMethod


### PR DESCRIPTION
### Problem
When Apipie is parsing resources it stores resources descriptions under a unique key in the `@resource_descriptions` hash in `Apipie::Application`. When generating such a key for a namespaced controller (e.g. `Api::AdUsers::SessionsController`) it will generate a name prefixed with the namespace to avoid collisions (e.g. `ad_users-sessions`). These names are generated using the `Application#get_resource_name` method. However, the Rspec validation helper does not use this method and instead uses `controller_name`, which is not prefixed. This causes all `match_declared_responses` calls to fail when testing namespaced resources.

### Solution
Use `Application#get_resource_name` to generate resource names in the Rspec helper.